### PR TITLE
[ADD]Kakao map added

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true,
+  reactStrictMode: false,
 
   swcMinify: true,
 

--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -1,10 +1,32 @@
-import React, { useRef } from "react";
+import React, { MutableRefObject, useEffect, useRef } from "react";
 import styled from "styled-components";
+import useGetCurrentLocation from "../../hooks/news/useGetCurrentLocation";
 
-const Map = () => {
-  const mapRef = useRef<HTMLDivElement>(null);
+type MapProps = { lat: string; lng: string };
 
-  return <MapContainer ref={mapRef} />;
+const Map = ({ lat, lng }: MapProps) => {
+  const myLocation = useGetCurrentLocation();
+  const kakaoMap = useRef<HTMLDivElement>(null);
+  const mapRef = useRef(null);
+
+  const initMap = () => {
+    if (typeof myLocation === "string") return;
+
+    const mapContainer = kakaoMap.current;
+    const mapOption = {
+      center: new kakao.maps.LatLng(myLocation.latitude, myLocation.longitude),
+      level: 3,
+    };
+
+    const map = new kakao.maps.Map(mapContainer as HTMLElement, mapOption);
+    (mapRef as MutableRefObject<any>).current = map;
+  };
+
+  useEffect(() => {
+    kakao.maps.load(() => initMap());
+  });
+
+  return <MapContainer ref={kakaoMap} />;
 };
 
 export default Map;

--- a/src/components/pages/Store/index.tsx
+++ b/src/components/pages/Store/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import Map from "../../Map";
 
 const StorePage = () => {
-  return <Map />;
+  return <Map lat="37.4979517" lng="127.0276188" />;
 };
 
 export default StorePage;

--- a/src/hooks/news/useGetCurrentLocation.ts
+++ b/src/hooks/news/useGetCurrentLocation.ts
@@ -1,0 +1,28 @@
+import React, { useEffect, useState } from "react";
+
+const useGetCurrentLocation = () => {
+  const [myLocation, setMyLocation] = useState<
+    { latitude: number; longitude: number } | string
+  >("");
+
+  useEffect(() => {
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(success, error);
+    }
+
+    function success(position: any) {
+      setMyLocation({
+        latitude: position.coords.latitude,
+        longitude: position.coords.longitude,
+      });
+      console.log(position.coords.latitude);
+    }
+
+    function error() {
+      setMyLocation({ latitude: 37.4979517, longitude: 127.0276188 });
+    }
+  }, []);
+  return myLocation;
+};
+
+export default useGetCurrentLocation;

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -4,14 +4,15 @@ import Script from "next/script";
 export default function Document() {
   return (
     <Html lang="ko">
-      <Head />
-      <body>
-        <Main />
-        <NextScript />
+      <Head>
         <Script
           src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_MAP_KEY}&libraries=services,clusterer&autoload=false`}
           strategy="beforeInteractive"
         />
+      </Head>
+      <body>
+        <Main />
+        <NextScript />
       </body>
     </Html>
   );


### PR DESCRIPTION
카카오맵 추가

카카오맵api 스크립트가 우선 실행되어야 하기 때문에, _document.tsx 의 Head 부분에 Script 태그를 활용해서 스크립트를 추가하여 kakao map api 를 활용할 수 있도록 하였습니다.

useGetCurrentLocation() 훅은, 브라우저에 접속했을때 위치허용을 통해서 해당 사용자의 현재 위치를 가져오고, 거부했을 경우 강남역의 위치를 가져오도록 하였습니다.

map 컴포넌트에서 useGetCurrentLocation 훅을 통해서 현재위치를 가져왔을때 해당 위치를 기준으로 지도가 형성되도록 하였습니다.

reactStrictMode 에서는 랜더링이 2번 실행되면서, 카카오지도가 겹쳐져서 지도를 이동하거나 줌인, 줌아웃을 했을경우 지도가 이상하게 나타나지는 현상이 생겨 strict 모드를 false로 하여 카카오 지도가 하나만 생성되도록 하였습니다.