### PR TITLE
[FIX]dependancy Array

### DIFF
--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useCallback, useEffect, useRef } from "react";
 import styled from "styled-components";
 import useGetCurrentLocation from "../../hooks/news/useGetCurrentLocation";
 
@@ -29,7 +29,7 @@ const Map = () => {
   const myLocation = useGetCurrentLocation();
   const kakaoMap = useRef<HTMLDivElement>(null);
 
-  const initMap = () => {
+  const initMap = useCallback(() => {
     if (myLocation === null) return;
     const mapContainer = kakaoMap.current;
     const mapOption = {
@@ -50,11 +50,11 @@ const Map = () => {
       });
       kakao.maps.event.addListener(marker, "click", function () {});
     });
-  };
+  }, [myLocation]);
 
   useEffect(() => {
     kakao.maps.load(() => initMap());
-  }, [myLocation]);
+  }, [initMap]);
 
   return (
     <>


### PR DESCRIPTION
useEffect의 의존성배열 수정

useEffect의 의존성 배열로 myLocation을 두었을때 오류발생 -> useEffect 내부의 함수 (initMap) 의 변화에 따라 useEffect가 작동되도록 수정해야함,

initMap 은 myLocation 값에 따라 작동하기 때문에 , useCallback 을 활용하여 myLocation이 변경될때에만 함수가 참조값을 바꾸도록 하고, initMap을 useEffect의 의존성 배열로 넘겨주어 myLocation의 값이 변경됨에따라 useEffect가 작동되도록 하였습니다.