### PR TITLE
[ADD]marker on kakaomap

### DIFF
--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -1,36 +1,18 @@
-import React, { useCallback, useEffect, useRef } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import styled from "styled-components";
 import useGetCurrentLocation from "../../hooks/utils/useGetCurrentLocation";
+import type { Store } from "../../hooks/stores/useGetStore";
 
-var POSITION = [
-  {
-    title: "카카오",
-    lat: 33.450705,
-    lng: 126.570677,
-  },
-  {
-    title: "생태연못",
-    lat: 33.450936,
-    lng: 126.569477,
-  },
-  {
-    title: "텃밭",
-    lat: 33.450879,
-    lng: 126.56994,
-  },
-  {
-    title: "근린공원",
-    lat: 33.451393,
-    lng: 126.570738,
-  },
-];
-
-const Map = () => {
+const Map = ({ store }: { store: Store[] }) => {
+  const [selectStore, setSelectStore] = useState<Store | null>(null);
+  const [markers, setMarkers] = useState<any[]>([]);
   const myLocation = useGetCurrentLocation();
   const kakaoMap = useRef<HTMLDivElement>(null);
+  const mapRef = useRef<any>(null);
 
   const initMap = useCallback(() => {
     if (myLocation === null) return;
+
     const mapContainer = kakaoMap.current;
     const mapOption = {
       center: new kakao.maps.LatLng(myLocation.latitude, myLocation.longitude),
@@ -38,23 +20,45 @@ const Map = () => {
     };
 
     const map = new kakao.maps.Map(mapContainer as HTMLElement, mapOption);
+    mapRef.current = map;
 
     map.setMinLevel(3);
-    map.setMaxLevel(8);
+    map.setMaxLevel(10);
+  }, [myLocation]);
 
-    POSITION.forEach(item => {
-      const marker = new kakao.maps.Marker({
-        map: map,
-        position: new kakao.maps.LatLng(item.lat, item.lng),
+  const getMarker = useCallback(() => {
+    let markerArray: any[] = [];
+
+    markers.forEach(item => item.setMap(null));
+    store?.forEach(item => {
+      const mapMarker = new kakao.maps.Marker({
+        map: mapRef.current,
+        position: new kakao.maps.LatLng(
+          Number(item.REFINE_WGS84_LAT),
+          Number(item.REFINE_WGS84_LOGT)
+        ),
         clickable: true,
       });
-      kakao.maps.event.addListener(marker, "click", function () {});
+      kakao.maps.event.addListener(mapMarker, "click", function () {
+        setSelectStore(item);
+        const markerCenter = new kakao.maps.LatLng(
+          Number(item.REFINE_WGS84_LAT),
+          Number(item.REFINE_WGS84_LOGT)
+        );
+        mapRef.current?.panTo(markerCenter);
+      });
+      markerArray.push(mapMarker);
     });
-  }, [myLocation]);
+    setMarkers(markerArray);
+  }, [store, mapRef]);
 
   useEffect(() => {
     kakao.maps.load(() => initMap());
   }, [initMap]);
+
+  useEffect(() => {
+    getMarker();
+  }, [getMarker, myLocation]);
 
   return (
     <>

--- a/src/components/pages/Store/index.tsx
+++ b/src/components/pages/Store/index.tsx
@@ -1,11 +1,23 @@
-import React from "react";
-import { useGetStore } from "../../../hooks/stores/useGetStore";
+import React, { ChangeEvent, useState } from "react";
+import { Store, useGetStore } from "../../../hooks/stores/useGetStore";
 import Map from "../../Map";
 
 const StorePage = () => {
+  const [text, setText] = useState("");
   const { data } = useGetStore();
 
-  return <Map />;
+  const inputHandler = (event: ChangeEvent<HTMLInputElement>) => {
+    setText(event.target.value);
+  };
+
+  return (
+    <>
+      <input type="text" onChange={inputHandler} />
+      <Map
+        store={data?.filter((item: Store) => item.CMPNM_NM?.includes(text))}
+      />
+    </>
+  );
 };
 
 export default StorePage;


### PR DESCRIPTION
불러온 데이터를 바탕으로 지도에 마커 찍어주기

불러온 데이터를 바탕으로 해서 카카오에 표시될 marker를 만들어주고, 만들어진 marker 배열을 state 에 저장해준다.

데이터가 변경되었을때마다 state에 저장되어있었던 marker배열을 forEach로 돌면서 marker.setMap(null) 을 하여 기존의 마커를 지워주고 새롭게 변경된 데이터를 기반으로 다시 마커를 찍어주는 방식으로 구현하였습니다.

처음 현재 내 위치에 맞춰 지도를 생성하면, 해당 지도를 useRef()에 할당하여 언제든 지도에 접근 할 수 있도록 세팅해줄 수 있다.

