### PR TITLE
[ADD]zustand setting

### DIFF
--- a/src/components/pages/Store/index.tsx
+++ b/src/components/pages/Store/index.tsx
@@ -1,21 +1,34 @@
-import React, { ChangeEvent, useState } from "react";
-import { Store, useGetStore } from "../../../hooks/stores/useGetStore";
+import React, { ChangeEvent, useEffect, useState } from "react";
+import {
+  fetchStore,
+  Store,
+  useGetStore,
+  getStore,
+} from "../../../hooks/stores/useGetStore";
+import { useSearchStore } from "../../../store";
 import Map from "../../Map";
 
 const StorePage = () => {
   const [text, setText] = useState("");
   const { data } = useGetStore();
+  const { setSearchResult, setSearchText } = useSearchStore();
 
   const inputHandler = (event: ChangeEvent<HTMLInputElement>) => {
     setText(event.target.value);
   };
 
+  const searchHandler = () => {
+    setSearchResult(
+      data?.filter((item: Store) => item.CMPNM_NM?.includes(text))
+    );
+    setSearchText(text);
+  };
+
   return (
     <>
+      <button onClick={searchHandler}>검색</button>
       <input type="text" onChange={inputHandler} />
-      <Map
-        store={data?.filter((item: Store) => item.CMPNM_NM?.includes(text))}
-      />
+      <Map store={data} />
     </>
   );
 };

--- a/src/hooks/stores/useGetStore.ts
+++ b/src/hooks/stores/useGetStore.ts
@@ -22,8 +22,12 @@ export const fetchStore = async () => {
   const { data } = await request({
     url: `/stores`,
   });
-
   return data;
+};
+
+export const getStore = async () => {
+  const response = await fetchStore();
+  return response;
 };
 
 export const useGetStore = () => {

--- a/src/pages/store.tsx
+++ b/src/pages/store.tsx
@@ -22,7 +22,7 @@ const StoreWrapper = styled.div``;
 
 export const getStaticProps: GetStaticProps = async () => {
   const queryClient = new QueryClient();
-  await queryClient.prefetchQuery(["news"], fetchStore);
+  await queryClient.prefetchQuery(["store"], fetchStore);
 
   return {
     props: {

--- a/src/store/index.tsx
+++ b/src/store/index.tsx
@@ -1,0 +1,16 @@
+import create from "zustand";
+import { Store } from "../hooks/stores/useGetStore";
+
+interface SearchState {
+  searchResult: Store[];
+  searchText: string;
+  setSearchResult: (result: Store[]) => void;
+  setSearchText: (text: string) => void;
+}
+
+export const useSearchStore = create<SearchState>(set => ({
+  searchResult: [],
+  searchText: "",
+  setSearchResult: (result: Store[]) => set({ searchResult: result }),
+  setSearchText: (text: string) => set({ searchText: text }),
+}));


### PR DESCRIPTION
주스탠드를 활용하여 전역으로 검색어,검색결과 관리

root 폴더에 store 폴더를 만들어서 zustand 전역관리 파일을 생성, 

검색결과, 검색어를 전역으로 관리하기 위해 searchResult, searchText 를 각각 선언해주고,

각각의 state 를 변경시켜줄 set함수를 선언하여, 검색결과배열과, 검색어를 바로 기존의 state에 덮어씌우도록 하였습니다.