### PR TITLE
[FIX]cluster

### DIFF
--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -60,6 +60,7 @@ const Map = ({ initStore }: { initStore: Store[] }) => {
 
   const getCluster = (markerArray: any) => {
     clusterer?.clear();
+    if (markerArray.length === 0) return;
     const cluster = new kakao.maps.MarkerClusterer({
       map: mapRef.current,
       markers: markerArray,


### PR DESCRIPTION
초기렌더링 시 위치허용을 껏을때 오류가 나는 상황을 수정

위치를 허용하였을때는 위치를 검색하는 동안 맵->마커->클러스터 순서로 생성이 되는데

위치허용을 끄는 경우에는 myLocation이 렌더링 시 바로 입력되기 때문에 마커와 클러스터가 바로 생성이되면서

클러스터 생성함수 (getCluster)의 marker 배열이 존재하지 않는경우가 생기면서, 클러스터 오류가 생겼습니다.

따라서 getCluster 함수를 호출하였을때 marker배열이 없는경우 early return 해주어 오류가 생성되지 않도록 하였습니다.
